### PR TITLE
FIX: pre-commit eslint returns babel config error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,16 +28,43 @@ repos:
         always_run: true
         pass_filenames: false
 
+# TODO: Add eslint to the pre-commit hooks
+# -   repo: local
+#     hooks:
+#     -   id: client
+#         name: client
+#         stages: [commit, push]
+#         language: system
+#         entry: npx
+#         args: 
+#         -   "eslint"
+#         -   "./client"
+#         always_run: true
+#         pass_filenames: false
+
+# -   repo: local
+#     hooks:
+#     -   id: server
+#         name: server
+#         stages: [commit, push]
+#         language: system
+#         entry: npx
+#         args: 
+#         -   "eslint"
+#         -   "./server"
+#         always_run: true
+#         pass_filenames: false
+
 -   repo: local
     hooks:
     -   id: client
         name: client
         stages: [commit, push]
         language: system
-        entry: npx
+        entry: bash
         args: 
-        -   "eslint"
-        -   "./client"
+        -   "-c"
+        -   "cd ./client && npm run test"
         always_run: true
         pass_filenames: false
 
@@ -47,9 +74,9 @@ repos:
         name: server
         stages: [commit, push]
         language: system
-        entry: npx
+        entry: bash
         args: 
-        -   "eslint"
-        -   "./server"
+        -   "-c"
+        -   "cd ./server && npm run test"
         always_run: true
         pass_filenames: false

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4138,7 +4138,6 @@
       "version": "9.3.4",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
       "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4236,8 +4235,7 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -12116,8 +12114,7 @@
     "node_modules/jest-validate/node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/jest-watch-typeahead": {
       "version": "1.1.0",
@@ -12846,7 +12843,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }

--- a/condense/summarizer.py
+++ b/condense/summarizer.py
@@ -38,7 +38,9 @@ def clean_data(data: list[str]) -> str:
         sentences = []
         # Removing extra whitespaces
         for sentence in data:
-            sentence = re.sub("[^a-zA-Z0-9.,;:()'\"\\s]", "", sentence["text"]) # Add special symbols to preserve inside the square brackets with numbers and characters
+            sentence = re.sub(
+                "[^a-zA-Z0-9.,;:()'\"\\s]", "", sentence["text"]
+            )  # Add special symbols to preserve inside the square brackets with numbers and characters
             sentence = re.sub("\\s+", " ", sentence)
             sentences.append(sentence.strip())
         display = " ".join(sentences)

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "bcrypt": "^5.1.1",
         "brcypt": "^1.0.1",
         "cors": "^2.8.5",
         "dotenv": "^16.4.1",
@@ -24,6 +23,7 @@
         "@babel/core": "^7.24.0",
         "@babel/eslint-parser": "^7.23.10",
         "@babel/preset-env": "^7.24.0",
+        "bcrypt": "^5.1.1",
         "eslint": "^8.57.0",
         "eslint-config-google": "^0.14.0",
         "eslint-config-prettier": "^9.1.0",
@@ -2490,6 +2490,7 @@
     },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.11",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "detect-libc": "^2.0.0",
@@ -2508,6 +2509,7 @@
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
       "version": "5.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "abbrev": "1"
@@ -2736,6 +2738,7 @@
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/accepts": {
@@ -2772,6 +2775,7 @@
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -2782,6 +2786,7 @@
     },
     "node_modules/agent-base/node_modules/debug": {
       "version": "4.3.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -2797,6 +2802,7 @@
     },
     "node_modules/agent-base/node_modules/ms": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ajv": {
@@ -2831,6 +2837,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2864,10 +2871,12 @@
     },
     "node_modules/aproba": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/are-we-there-yet": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "delegates": "^1.0.0",
@@ -3263,12 +3272,15 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/bcrypt": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz",
+      "integrity": "sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==",
+      "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.11",
         "node-addon-api": "^5.0.0"
@@ -3309,6 +3321,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3515,6 +3528,7 @@
     },
     "node_modules/chownr": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -3584,6 +3598,7 @@
     },
     "node_modules/color-support": {
       "version": "1.1.3",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "color-support": "bin.js"
@@ -3610,10 +3625,12 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/content-disposition": {
@@ -3788,6 +3805,7 @@
     },
     "node_modules/delegates": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/depd": {
@@ -3807,6 +3825,7 @@
     },
     "node_modules/detect-libc": {
       "version": "2.0.2",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -3888,6 +3907,7 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -4739,6 +4759,7 @@
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -4749,6 +4770,7 @@
     },
     "node_modules/fs-minipass/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -4759,6 +4781,7 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/function-bind": {
@@ -4797,6 +4820,7 @@
     },
     "node_modules/gauge": {
       "version": "3.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^1.0.3 || ^2.0.0",
@@ -4885,6 +4909,7 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -5022,6 +5047,7 @@
     },
     "node_modules/has-unicode": {
       "version": "2.0.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/hasown": {
@@ -5064,6 +5090,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -5075,6 +5102,7 @@
     },
     "node_modules/https-proxy-agent/node_modules/debug": {
       "version": "4.3.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -5090,6 +5118,7 @@
     },
     "node_modules/https-proxy-agent/node_modules/ms": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/human-signals": {
@@ -5177,6 +5206,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -5343,6 +5373,7 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6479,6 +6510,7 @@
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^6.0.0"
@@ -6492,6 +6524,7 @@
     },
     "node_modules/make-dir/node_modules/semver": {
       "version": "6.3.1",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6581,6 +6614,7 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -6591,6 +6625,7 @@
     },
     "node_modules/minipass": {
       "version": "5.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=8"
@@ -6598,6 +6633,7 @@
     },
     "node_modules/minizlib": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^3.0.0",
@@ -6609,6 +6645,7 @@
     },
     "node_modules/minizlib/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -6619,6 +6656,7 @@
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -6757,10 +6795,12 @@
     },
     "node_modules/node-addon-api": {
       "version": "5.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -6779,14 +6819,17 @@
     },
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -6890,6 +6933,7 @@
     },
     "node_modules/npmlog": {
       "version": "5.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "are-we-there-yet": "^2.0.0",
@@ -7141,6 +7185,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7385,6 +7430,7 @@
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -7579,6 +7625,7 @@
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -7724,6 +7771,7 @@
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/set-function-length": {
@@ -7797,6 +7845,7 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/simple-update-notifier": {
@@ -7872,6 +7921,7 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -7891,6 +7941,7 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7968,6 +8019,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -8102,6 +8154,7 @@
     },
     "node_modules/tar": {
       "version": "6.2.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
@@ -8412,6 +8465,7 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -8559,6 +8613,7 @@
     },
     "node_modules/wide-align": {
       "version": "1.1.5",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "bcrypt": "^5.1.1",
     "brcypt": "^1.0.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.1",
@@ -27,6 +26,7 @@
     "@babel/core": "^7.24.0",
     "@babel/eslint-parser": "^7.23.10",
     "@babel/preset-env": "^7.24.0",
+    "bcrypt": "^5.1.1",
     "eslint": "^8.57.0",
     "eslint-config-google": "^0.14.0",
     "eslint-config-prettier": "^9.1.0",


### PR DESCRIPTION
This PR addresses the [issue](https://linear.app/software-engineering-team-7/issue/SOF-126/bug-pre-commit-eslint-returns-babel-config-error), where the pre-commit eslint hook returns a Babel configuration error.